### PR TITLE
Fix install-python on Python <3.4

### DIFF
--- a/bin/install-python
+++ b/bin/install-python
@@ -46,8 +46,14 @@ def main() -> int:
         ppa = 'ppa:deadsnakes/ppa'
 
     py = f'python{version}'
-    packages = [f'{py}-dev', f'{py}-venv']
-    if float(version) >= 3.9:
+    packages = [f'{py}-dev']
+
+    numeric_version = float(version)
+
+    if numeric_version >= 3.4:
+        packages.append(f'{py}-venv')
+
+    if numeric_version >= 3.9:
         packages.append(f'{py}-distutils')
     else:
         packages.append('python3-distutils')
@@ -70,7 +76,8 @@ def main() -> int:
         ),
         Group.make(
             f'set up {py} environment',
-            (py, '-mvenv', envdir),
+            *(((py, '-mvenv', envdir) if numeric_version >= 3.4 else
+               ('pyvenv', envdir)),),
             (pip, 'install', '--upgrade', 'pip', 'setuptools', 'wheel'),
         ),
     )


### PR DESCRIPTION
The venv module was introduced in Python 3.3, but the deadsnakes PPA doesn't include a python3.3-venv package.

[Here is an example where this breaks](https://github.com/dateutil/dateutil/runs/1342724199?check_suite_focus=true).

I guess per #6 there are no tests, so it's hard to know if this will work I guess.