### PR TITLE
Fix removed add-path command

### DIFF
--- a/bin/install-python
+++ b/bin/install-python
@@ -81,7 +81,9 @@ def main() -> int:
                 if _print_call(*cmd):
                     return 1
 
-    print(f'::add-path::{bindir}')
+    with open(os.environ['GITHUB_PATH'], 'a') as fp:
+        fp.write(f'{bindir}\n')
+
     return 0
 
 


### PR DESCRIPTION
Fixes https://github.com/deadsnakes/issues/issues/135

Before the fix: [job](https://github.com/atugushev/pip-tools/runs/1425896223?check_suite_focus=true#step:4:181)
After the fix: [job](https://github.com/atugushev/pip-tools/runs/1425966809?check_suite_focus=true#step:4:154)

See [new usage](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#adding-a-system-path).
See [removal log](https://github.blog/changelog/2020-11-09-github-actions-removing-set-env-and-add-path-commands-on-november-16/).

