### PR TITLE
Allow installation of debug version of Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ jobs:
         if: endsWith(matrix.python-version, '-dev')
         with:
           python-version: ${{ matrix.python-version }}
+          # debug: true  # Optional, to select a Python debug build
       - run: python --version --version && which python
 ```
 
@@ -42,6 +43,9 @@ jobs:
     - [available nightly versions]
 - to use tagged builds, just use the version number
     - [available versions]
+
+In either case, the actions's `debug` input can be used to install a
+debug build of the selected Python version.
 
 note: this action is incompatible with ubuntu-16.04 due to a limitation in
 `add-apt-repository`

--- a/action.yml
+++ b/action.yml
@@ -4,9 +4,13 @@ inputs:
   python-version:
     description: python version to use, such as '3.9'
     required: true
+  debug:
+    description: use debug version of python
+    required: false
+    default: false
 runs:
   using: composite
   steps:
-  - name: add deadsnakes ppa and install ${{ inputs.python-version }}
-    run: ${{ github.action_path }}/bin/install-python ${{ inputs.python-version }}
+  - name: add deadsnakes ppa and install ${{ inputs.python-version }} ${{ inputs.debug && '(debug)' || '' }}
+    run: ${{ github.action_path }}/bin/install-python ${{ inputs.python-version }} ${{ inputs.debug && '--debug' || '' }}
     shell: bash

--- a/bin/install-python
+++ b/bin/install-python
@@ -36,6 +36,7 @@ def _print_call(*args: str) -> int:
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('version')
+    parser.add_argument('--debug', action='store_true')
     args = parser.parse_args()
 
     if args.version.endswith('-dev'):
@@ -51,10 +52,13 @@ def main() -> int:
         packages.append(f'{py}-distutils')
     else:
         packages.append('python3-distutils')
+    if args.debug:
+        packages.append(f'{py}-dbg')
 
     envdir = os.path.expanduser(f'~/venv-{version}')
     bindir = os.path.join(envdir, 'bin')
     pip = os.path.join(bindir, 'pip')
+    py_executable = f'{py}-dbg' if args.debug else py
 
     groups = (
         Group.make(
@@ -69,8 +73,8 @@ def main() -> int:
             ),
         ),
         Group.make(
-            f'set up {py} environment',
-            (py, '-mvenv', envdir),
+            f'set up {py_executable} environment',
+            (py_executable, '-mvenv', envdir),
             (pip, 'install', '--upgrade', 'pip', 'setuptools', 'wheel'),
         ),
     )


### PR DESCRIPTION
It would be useful if the GitHub Action could also easily install and setup a debug version of Python. This PR recognizes a `-dbg` suffix, and also install the debug version and uses it to setup the virtual environment.

Since there are no tests, I am already using my branch in the CI runs here, and it seems to work: https://github.com/pybind/pybind11/pull/2746

Things to consider:
- `-dbg-dev` or `-dev-dbg` isn't recognized/allowed, but the nightly builds don't seem to have a debug version?
- Another option would be to add another argument to the action `dbg: true` or `debug: true`; this might make more sense if the nightly builds would have a debug build, but if they don't, it might be unexpected that such a combination would not work?
- The virtual environment is still created in `~/venv-{version}`. Should this be `~/venv-{version}-dbg`, such that two installations of the same version could coexist as debug and non-debug build? But then `-dev` doesn't currently allow this either, it seems.