### PR TITLE
Fix the issue that input values seems to be strings rather than e.g. booleans

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ jobs:
     - [available versions]
 
 In either case, the actions's `debug` input can be used to install a
-debug build of the selected Python version.
+debug build of the selected Python version, by adding `debug: true`.
 
 note: this action is incompatible with ubuntu-16.04 due to a limitation in
 `add-apt-repository`

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,6 @@ inputs:
 runs:
   using: composite
   steps:
-  - name: add deadsnakes ppa and install ${{ inputs.python-version }} ${{ inputs.debug && '(debug)' || '' }}
-    run: ${{ github.action_path }}/bin/install-python ${{ inputs.python-version }} ${{ inputs.debug && '--debug' || '' }}
+  - name: add deadsnakes ppa and install ${{ inputs.python-version }} ${{ inputs.debug == 'true' && '(debug)' || '' }}
+    run: ${{ github.action_path }}/bin/install-python ${{ inputs.python-version }} ${{ inputs.debug == 'true' && '--debug' || '' }}
     shell: bash


### PR DESCRIPTION
Seems I made a mistake in #18. The values of an action's input are always strings, so even when passing `false` (the boolean), that's going to be `'false'` (the string) and thus interpreted as `true` (the boolean).

Found in pybind/pybind11#2792, demonstrating the fix. Compare the following two commits:
- With `deadsnakes/action@2.1.0`: https://github.com/pybind/pybind11/runs/1698416221#step:3:76 (include `python3.10-dbg`)
- With `YannickJadoul/deadsnakes-action@fix-input-boolean`: https://github.com/pybind/pybind11/runs/1698540649#step:3:76 (doesn't include `python3.10-dbg` anymore)

Sorry for not catching this in #18! The default values for the inputs `action.yml` _are_ apparently booleans...