### PR TITLE
Make Action usable inside a Docker container

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,10 @@ jobs:
         - {python: '3.12-dev', debug: false, image: null}
     container: ${{ matrix.image }}
     steps:
+    - name: Install Dependencies in Container
+      if: ${{ matrix.image }}
+      run: |
+        apt-get update && apt-get install -y sudo python3
     - uses: actions/checkout@v3
     - uses: ./.
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,13 +18,11 @@ jobs:
         - {python: '3.11-dev', debug: false, image: null}
         - {python: '3.12-dev', debug: false, image: null}
     container: ${{ matrix.image }}
-    env:
-      DEBIAN_FRONTEND: noninteractive # to prevent apt-get from waiting user input
     steps:
     - name: Install Dependencies in Container
       if: ${{ matrix.image }}
       run: |
-        apt-get update && apt-get install -y sudo software-properties-common python3
+        apt-get update && apt-get install -y sudo software-properties-common dialog python3
     - uses: actions/checkout@v3
     - uses: ./.
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install Dependencies in Container
       if: ${{ matrix.image }}
       run: |
-        apt-get update && apt-get install -y sudo python3
+        apt-get update && apt-get install -y sudo software-properties-common python3
     - uses: actions/checkout@v3
     - uses: ./.
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,9 @@ jobs:
       matrix:
         include:
         - {python: '3.7', debug: true, image: null}
+        - {python: '3.11', debug: false, image: 'ubuntu:latest'}
         - {python: '3.11-dev', debug: false, image: null}
         - {python: '3.12-dev', debug: false, image: null}
-        - {python: '3.12-dev', debug: false, image: 'ubuntu:latest'}
     container: ${{ matrix.image }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,11 +18,7 @@ jobs:
     steps:
     - name: Install Dependencies in Container
       if: ${{ matrix.image }}
-      run: |
-        apt-get update && apt-get install -y sudo software-properties-common python3
-        
-        # To prevent waiting for user-input when configuring `tzdata`  
-        eval "$(sudo tee --append /etc/environment <<<'DEBIAN_FRONTEND=noninteractive')"
+      run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y sudo software-properties-common python3 tzdata
     - uses: actions/checkout@v3
     - uses: ./.
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,6 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
     strategy:
       fail-fast: false
       matrix:
@@ -22,7 +19,10 @@ jobs:
     - name: Install Dependencies in Container
       if: ${{ matrix.image }}
       run: |
-        apt-get update && apt-get install -y sudo software-properties-common dialog python3
+        apt-get update && apt-get install -y sudo software-properties-common python3
+        
+        # To prevent waiting for user-input when configuring `tzdata`  
+        eval "$(sudo tee --append /etc/environment <<<'DEBIAN_FRONTEND=noninteractive')"
     - uses: actions/checkout@v3
     - uses: ./.
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
         - {python: '3.7', debug: true, image: null}
@@ -14,6 +15,8 @@ jobs:
         - {python: '3.11-dev', debug: false, image: null}
         - {python: '3.12-dev', debug: false, image: null}
     container: ${{ matrix.image }}
+    env:
+      DEBIAN_FRONTEND: noninteractive # to prevent apt-get from waiting user input
     steps:
     - name: Install Dependencies in Container
       if: ${{ matrix.image }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,9 +9,11 @@ jobs:
     strategy:
       matrix:
         include:
-        - {python: '3.7', debug: true}
-        - {python: '3.11-dev', debug: false}
-        - {python: '3.12-dev', debug: false}
+        - {python: '3.7', debug: true, image: null}
+        - {python: '3.11-dev', debug: false, image: null}
+        - {python: '3.12-dev', debug: false, image: null}
+        - {python: '3.12-dev', debug: false, image: 'ubuntu:latest'}
+    container: ${{ matrix.image }}
     steps:
     - uses: actions/checkout@v3
     - uses: ./.

--- a/action.yml
+++ b/action.yml
@@ -8,30 +8,18 @@ inputs:
     description: use debug version of python
     required: false
     default: false
+  inside-container:
+    description: if the action will run inside a container
+    required: false
+    default: false
 runs:
   using: composite
   steps:
-
-  - name: Add the action path to the gh paths to find scripts
-    shell: bash
-    run: |
-      # Both needed because they are unexpectedly different for containers apparently:
-      # https://github.com/actions/runner/pull/1762#issuecomment-1105843659
-      echo "${{ github.action_path }}" >> $GITHUB_PATH
-      echo "$GITHUB_ACTION_PATH" >> $GITHUB_PATH
-
-  - name: Echo Actions Path
-    shell: bash
-    run: |
-      echo $GITHUB_ACTION_PATH
-      echo ${{ github.action_path }}
-
-  - name: Echo
-    shell: bash
-    run: |
-      echo $(pwd)
-      ls -laR $(pwd)
-
   - name: add deadsnakes ppa and install ${{ inputs.python-version }} ${{ inputs.debug == 'true' && '(debug)' || '' }}
-    run: ./bin/install-python ${{ inputs.python-version }} ${{ inputs.debug == 'true' && '--debug' || '' }}
     shell: bash
+    run: |
+      if [[ "${{ inputs.inside-container }}" == "false" ]]; then
+        ${{ github.action_path }}/bin/install-python ${{ inputs.python-version }} ${{ inputs.debug == 'true' && '--debug' || '' }}
+      else
+        $GITHUB_ACTION_PATH/bin/install-python ${{ inputs.python-version }} ${{ inputs.debug == 'true' && '--debug' || '' }}
+      fi

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,11 @@ runs:
       echo "${{ github.action_path }}" >> $GITHUB_PATH
       echo "$GITHUB_ACTION_PATH" >> $GITHUB_PATH
 
+  - name: Echo
+    run: |
+      echo $(pwd)
+      ls -laR $(pwd)
+
   - name: add deadsnakes ppa and install ${{ inputs.python-version }} ${{ inputs.debug == 'true' && '(debug)' || '' }}
     run: ./bin/install-python ${{ inputs.python-version }} ${{ inputs.debug == 'true' && '--debug' || '' }}
     shell: bash

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,7 @@ runs:
       echo "$GITHUB_ACTION_PATH" >> $GITHUB_PATH
 
   - name: Echo
+    shell: bash
     run: |
       echo $(pwd)
       ls -laR $(pwd)

--- a/action.yml
+++ b/action.yml
@@ -21,5 +21,5 @@ runs:
       echo "$GITHUB_ACTION_PATH" >> $GITHUB_PATH
 
   - name: add deadsnakes ppa and install ${{ inputs.python-version }} ${{ inputs.debug == 'true' && '(debug)' || '' }}
-    run: ${{ github.action_path }}/bin/install-python ${{ inputs.python-version }} ${{ inputs.debug == 'true' && '--debug' || '' }}
+    run: ./bin/install-python ${{ inputs.python-version }} ${{ inputs.debug == 'true' && '--debug' || '' }}
     shell: bash

--- a/action.yml
+++ b/action.yml
@@ -8,18 +8,17 @@ inputs:
     description: use debug version of python
     required: false
     default: false
-  inside-container:
-    description: if the action will run inside a container
-    required: false
-    default: false
 runs:
   using: composite
   steps:
   - name: add deadsnakes ppa and install ${{ inputs.python-version }} ${{ inputs.debug == 'true' && '(debug)' || '' }}
     shell: bash
     run: |
-      if [[ "${{ inputs.inside-container }}" == "false" ]]; then
+      # The `github.action_path` path is incorrectly set if the action is executed inside a container
+      # So one has to use `GITHUB_ACTION_PATH` instead
+      # e.g.: https://github.com/actions/runner/issues/2185 & https://github.com/actions/runner/pull/1762#issuecomment-1105843659
+      if [[ -f "${{ github.action_path }}/bin/install-python" ]]; then
         ${{ github.action_path }}/bin/install-python ${{ inputs.python-version }} ${{ inputs.debug == 'true' && '--debug' || '' }}
-      else
+      elif [[ -f "$GITHUB_ACTION_PATH/bin/install-python" ]]; then
         $GITHUB_ACTION_PATH/bin/install-python ${{ inputs.python-version }} ${{ inputs.debug == 'true' && '--debug' || '' }}
       fi

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,12 @@ runs:
       echo "${{ github.action_path }}" >> $GITHUB_PATH
       echo "$GITHUB_ACTION_PATH" >> $GITHUB_PATH
 
+  - name: Echo Actions Path
+    shell: bash
+    run: |
+      echo $GITHUB_ACTION_PATH
+      echo ${{ github.action_path }}
+
   - name: Echo
     shell: bash
     run: |

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ runs:
   - name: add deadsnakes ppa and install ${{ inputs.python-version }} ${{ inputs.debug == 'true' && '(debug)' || '' }}
     shell: bash
     run: |
-      # The `github.action_path` path is incorrectly set if the action is executed inside a container
+      # The `github.action_path` path is incorrectly set if the action is executed inside a Docker container
       # So one has to use `GITHUB_ACTION_PATH` instead
       # e.g.: https://github.com/actions/runner/issues/2185 & https://github.com/actions/runner/pull/1762#issuecomment-1105843659
       if [[ -f "${{ github.action_path }}/bin/install-python" ]]; then

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,15 @@ inputs:
 runs:
   using: composite
   steps:
+
+  - name: Add the action path to the gh paths to find scripts
+    shell: bash
+    run: |
+      # Both needed because they are unexpectedly different for containers apparently:
+      # https://github.com/actions/runner/pull/1762#issuecomment-1105843659
+      echo "${{ github.action_path }}" >> $GITHUB_PATH
+      echo "$GITHUB_ACTION_PATH" >> $GITHUB_PATH
+
   - name: add deadsnakes ppa and install ${{ inputs.python-version }} ${{ inputs.debug == 'true' && '(debug)' || '' }}
     run: ${{ github.action_path }}/bin/install-python ${{ inputs.python-version }} ${{ inputs.debug == 'true' && '--debug' || '' }}
     shell: bash


### PR DESCRIPTION
Hi, 

We are using this action to install Python on ARM machines and the workflow steps are executed inside a container (almost bare `ubuntu:20.04`). 

There is a known problem with `github.action_path` - it is incorrectly set if the action is executed inside a container:  [1](https://github.com/actions/runner/issues/2185), [2](https://github.com/actions/runner/pull/1762#issuecomment-1105843659). We have [encountered](https://github.com/openvinotoolkit/openvino/actions/runs/6771647677/job/18402486470) it ourselves when trying to use the action. It failed with: 
![image](https://github.com/deadsnakes/action/assets/65596953/bedae3b5-03aa-4489-9f53-dfa085f7ad82)

The proposed fix is to check if the `install_python` script exists under either of the two paths: 
* `${{ github.action_path }}/bin/` - for the outside container scenario
* `$GITHUB_ACTION_PATH/bin/` - for the inside container scenario

I've added the matrix entry with a Docker image to check if this would work: [it works](https://github.com/akashchi/deadsnakes-action/actions/runs/6784617290/job/18441270210).